### PR TITLE
fix(security): suppress Trivy GO-2026-5932 openpgp advisory (#228)

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -3,3 +3,10 @@
 # The app explicitly configures safe Kratos 404/405 fallback handlers via
 # internal/pkg/xhttp.SafeKratosServerOptions to avoid http.DefaultServeMux.
 CVE-2026-6993
+# GO-2026-5932: golang.org/x/crypto/openpgp is unmaintained/unsafe by design.
+# The advisory has no fixed version (upstream has not removed openpgp from
+# x/crypto). This app does NOT import crypto/openpgp — it only uses
+# golang.org/x/crypto/bcrypt (cmd/admin-reset, app/identity/internal/biz).
+# Trivy flags the entire module because the openpgp subpackage exists within
+# it. Suppressed until upstream removes openpgp or a fixed version is released.
+GO-2026-5932


### PR DESCRIPTION
## Fix for alert #228

`GO-2026-5932` reports that `golang.org/x/crypto/openpgp` is unmaintained and unsafe by design. However, the advisory has **no fixed version** — upstream has not removed the `openpgp` subpackage from `golang.org/x/crypto`, so simply upgrading the module (already bumped to v0.54.0, the latest) cannot resolve the alert.

### Evidence the app is not affected
- No `crypto/openpgp` imports exist anywhere in the codebase (verified via `grep -rn openpgp --include='*.go'`).
- The only direct `golang.org/x/crypto` import is `golang.org/x/crypto/bcrypt` (used for password hashing in `cmd/admin-reset` and `app/identity/internal/biz`).
- Trivy flags the entire module because the `openpgp` subpackage exists within it.

### Fix
Add `GO-2026-5932` to `.trivyignore` with a documented justification, mirroring the existing `CVE-2026-6993` suppression pattern for kratos. This ensures the security pipeline no longer reports this non-actionable, non-exploited advisory.
