### PR TITLE
ci(release): gate releases with shared e2e workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,138 @@
+name: Reusable E2E
+
+# Shared release/nightly gate. Keep this workflow as the single source of
+# truth for compose E2E and Playwright admin smoke so the release gate cannot
+# drift from the nightly stability evidence.
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: Git ref to test
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  compose-e2e:
+    name: Compose E2E suite
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.26'
+          cache: true
+
+      # api/**/*.pb.go and internal/conf/*.pb.go are git-ignored and generated
+      # locally by `make api`; a clean checkout has none of them. The Go e2e
+      # suite imports the generated stubs, so install the pinned buf +
+      # protobuf generators and regenerate before compiling (mirrors ci.yml).
+      - name: Install buf and protobuf generators
+        run: |
+          make init
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+
+      - name: Generate API stubs
+        run: make api config
+
+      # .env is git-ignored (deployments/docker-compose/.env) and absent in a
+      # clean checkout, but docker-compose.yml hard-requires
+      # ${MYSQL_ROOT_PASSWORD:?} and ${ADMIN_TOKEN:?}. Seed it from the example
+      # so the compose stack and the e2e script agree.
+      - name: Prepare compose environment
+        run: |
+          if [ ! -f deployments/docker-compose/.env ]; then
+            cp deployments/docker-compose/.env.example deployments/docker-compose/.env
+            echo "Seeded .env from .env.example"
+          fi
+
+      - name: Run compose E2E suite
+        id: e2e
+        env:
+          # Keep the compose stack alive on failure so the diagnostics steps
+          # below can collect logs and container state before teardown.
+          E2E_KEEP_ON_FAILURE: "1"
+        run: make test-e2e-suite
+        timeout-minutes: 30
+
+      # E2E_KEEP_ON_FAILURE leaves the stack running on failure (see
+      # scripts/test-e2e-flow.sh), so containers are still alive here. Dump
+      # full compose logs + container state to /tmp for the artifact upload —
+      # the step output alone truncates, and the script's own mktemp logs are
+      # deleted before this step runs.
+      - name: Collect container state (on failure)
+        if: failure()
+        run: |
+          cd deployments/docker-compose
+          docker compose -f docker-compose.yml -f docker-compose.test.yml ps -a > /tmp/compose-ps.txt 2>&1 || true
+          docker compose -f docker-compose.yml -f docker-compose.test.yml logs --no-color --tail 500 > /tmp/compose-logs.log 2>&1 || true
+          for c in mysql redis mock-upstream identity-service channel-service billing-service relay-gateway; do
+            echo "===== $c ====="
+            docker logs --tail 200 "$c" 2>&1 || true
+          done
+        shell: bash
+
+      - name: Upload failure diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: compose-e2e-diagnostics
+          path: |
+            /tmp/compose-ps.txt
+            /tmp/compose-logs.log
+          if-no-files-found: ignore
+
+      - name: Tear down compose stack
+        if: always()
+        run: |
+          cd deployments/docker-compose
+          docker compose -f docker-compose.yml -f docker-compose.test.yml down -v --remove-orphans || true
+
+  frontend-smoke:
+    name: Playwright admin smoke
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: web
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Set up Node
+        uses: actions/setup-node@v5
+        with:
+          node-version: '24'
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      # playwright.config.ts uses channel: 'chrome' for both projects, which
+      # requires Google Chrome — installing chromium would fail at runtime
+      # with "Executable doesn't exist".
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chrome
+
+      - name: Run Playwright admin smoke
+        run: npx playwright test
+        timeout-minutes: 15
+
+      - name: Upload Playwright report (on failure)
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-report
+          path: |
+            web/playwright-report/
+            web/test-results/
+          if-no-files-found: ignore

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,144 +1,23 @@
 name: Nightly E2E
 
-# v0.19 P1.3: integration/e2e layering.
-#
-# The per-PR gate (`ci.yml`) runs unit + race + architecture + migration-check
-# (+ a new integration-smoke job). This workflow runs the heavyweight suites
-# that need a real compose environment and a browser, on a nightly cadence
-# (and on demand via workflow_dispatch):
-#   - compose e2e: make test-e2e-suite (real services + MySQL + Redis + mock
-#     upstream), asserting the full register→login→models→chat→billing chain;
-#   - frontend Playwright smoke: web/e2e/admin-smoke.spec.ts against the dev
-#     server, covering admin routing + auth + core management flows.
-#
-# On failure, artifacts (service logs, docker container state, Playwright
-# traces/reports) are uploaded so the breakage can be diagnosed without
-# re-running the whole suite.
+# v0.21: nightly now invokes the shared E2E workflow. This file owns cadence
+# only; compose E2E and Playwright admin smoke steps live in e2e.yml so the
+# release gate and nightly stability evidence cannot drift apart.
 
 on:
   schedule:
     - cron: '0 2 * * *'  # Daily at 02:00 UTC
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: nightly-e2e-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
-  compose-e2e:
-    name: Compose E2E suite
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v5
-
-      - name: Set up Go
-        uses: actions/setup-go@v6
-        with:
-          go-version: '1.26'
-          cache: true
-
-      # api/**/*.pb.go and internal/conf/*.pb.go are git-ignored and generated
-      # locally by `make api`; a clean checkout has none of them. The Go e2e
-      # suite imports the generated stubs, so install the pinned buf +
-      # protobuf generators and regenerate before compiling (mirrors ci.yml).
-      - name: Install buf and protobuf generators
-        run: |
-          make init
-          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
-
-      - name: Generate API stubs
-        run: make api config
-
-      # .env is git-ignored (deployments/docker-compose/.env) and absent in a
-      # clean checkout, but docker-compose.yml hard-requires
-      # ${MYSQL_ROOT_PASSWORD:?} and ${ADMIN_TOKEN:?}. Seed it from the example
-      # so the compose stack and the e2e script agree.
-      - name: Prepare compose environment
-        run: |
-          if [ ! -f deployments/docker-compose/.env ]; then
-            cp deployments/docker-compose/.env.example deployments/docker-compose/.env
-            echo "Seeded .env from .env.example"
-          fi
-
-      - name: Run compose E2E suite
-        id: e2e
-        env:
-          # Keep the compose stack alive on failure so the diagnostics steps
-          # below can collect logs and container state before teardown.
-          E2E_KEEP_ON_FAILURE: "1"
-        run: make test-e2e-suite
-        timeout-minutes: 30
-
-      # E2E_KEEP_ON_FAILURE leaves the stack running on failure (see
-      # scripts/test-e2e-flow.sh), so containers are still alive here. Dump
-      # full compose logs + container state to /tmp for the artifact upload —
-      # the step output alone truncates, and the script's own mktemp logs are
-      # deleted before this step runs.
-      - name: Collect container state (on failure)
-        if: failure()
-        run: |
-          cd deployments/docker-compose
-          docker compose -f docker-compose.yml -f docker-compose.test.yml ps -a > /tmp/compose-ps.txt 2>&1 || true
-          docker compose -f docker-compose.yml -f docker-compose.test.yml logs --no-color --tail 500 > /tmp/compose-logs.log 2>&1 || true
-          for c in mysql redis mock-upstream identity-service channel-service billing-service relay-gateway; do
-            echo "===== $c ====="
-            docker logs --tail 200 "$c" 2>&1 || true
-          done
-        shell: bash
-
-      - name: Upload failure diagnostics
-        if: failure()
-        uses: actions/upload-artifact@v7
-        with:
-          name: compose-e2e-diagnostics
-          path: |
-            /tmp/compose-ps.txt
-            /tmp/compose-logs.log
-          if-no-files-found: ignore
-
-      - name: Tear down compose stack
-        if: always()
-        run: |
-          cd deployments/docker-compose
-          docker compose -f docker-compose.yml -f docker-compose.test.yml down -v --remove-orphans || true
-
-  frontend-smoke:
-    name: Playwright admin smoke
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: web
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v5
-
-      - name: Set up Node
-        uses: actions/setup-node@v5
-        with:
-          node-version: '24'
-          cache: npm
-          cache-dependency-path: web/package-lock.json
-
-      - name: Install dependencies
-        run: npm ci
-
-      # playwright.config.ts uses channel: 'chrome' for both projects, which
-      # requires Google Chrome — installing chromium would fail at runtime
-      # with "Executable doesn't exist".
-      - name: Install Playwright browsers
-        run: npx playwright install --with-deps chrome
-
-      - name: Run Playwright admin smoke
-        run: npx playwright test
-        timeout-minutes: 15
-
-      - name: Upload Playwright report (on failure)
-        if: failure()
-        uses: actions/upload-artifact@v7
-        with:
-          name: playwright-report
-          path: |
-            web/playwright-report/
-            web/test-results/
-          if-no-files-found: ignore
+  e2e:
+    uses: ./.github/workflows/e2e.yml
+    with:
+      ref: ${{ github.sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Release tag to publish'
+        description: Release tag to publish
         required: true
         type: string
 
@@ -15,6 +15,29 @@ permissions:
   contents: write
 
 jobs:
+  release-context:
+    name: Resolve release context
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.meta.outputs.tag }}
+    steps:
+      - name: Resolve release tag
+        id: meta
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            tag="${{ inputs.tag }}"
+          else
+            tag="${{ github.ref_name }}"
+          fi
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+  e2e:
+    name: Release E2E gate
+    needs: release-context
+    uses: ./.github/workflows/e2e.yml
+    with:
+      ref: ${{ needs.release-context.outputs.tag }}
+
   services:
     name: Load service matrix
     runs-on: ubuntu-latest
@@ -36,22 +59,12 @@ jobs:
       fail-fast: false
       matrix:
         include: ${{ fromJSON(needs.services.outputs.matrix) }}
-    needs: services
+    needs: [release-context, services, e2e]
     steps:
-      - name: Resolve release tag
-        id: meta-tag
-        run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            tag="${{ inputs.tag }}"
-          else
-            tag="${{ github.ref_name }}"
-          fi
-          echo "tag=$tag" >> "$GITHUB_OUTPUT"
-
       - name: Checkout code
         uses: actions/checkout@v5
         with:
-          ref: ${{ steps.meta-tag.outputs.tag }}
+          ref: ${{ needs.release-context.outputs.tag }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
@@ -73,9 +86,9 @@ jobs:
           # Gate the mutable 'latest' tag on non-prerelease semver so a
           # v0.14.0-rc1 tag cannot clobber the stable 'latest' (code-review L4).
           tags: |
-            type=raw,value=${{ steps.meta-tag.outputs.tag }}
-            type=semver,pattern={{major}}.{{minor}},enable=${{ !contains(steps.meta-tag.outputs.tag, '-') }}
-            type=raw,value=latest,enable=${{ !contains(steps.meta-tag.outputs.tag, '-') }}
+            type=raw,value=${{ needs.release-context.outputs.tag }}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ !contains(needs.release-context.outputs.tag, '-') }}
+            type=raw,value=latest,enable=${{ !contains(needs.release-context.outputs.tag, '-') }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v7
@@ -96,29 +109,19 @@ jobs:
 
   publish:
     name: Publish GitHub Release
-    needs: docker
+    needs: [release-context, docker]
     runs-on: ubuntu-latest
     steps:
-      - name: Resolve release tag
-        id: meta
-        run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            tag="${{ inputs.tag }}"
-          else
-            tag="${{ github.ref_name }}"
-          fi
-          echo "tag=$tag" >> "$GITHUB_OUTPUT"
-
       - name: Checkout code
         uses: actions/checkout@v5
         with:
-          ref: ${{ steps.meta.outputs.tag }}
+          ref: ${{ needs.release-context.outputs.tag }}
 
       - name: Verify release notes exist
-        run: test -f "docs/releases/release-${{ steps.meta.outputs.tag }}.md"
+        run: test -f "docs/releases/release-${{ needs.release-context.outputs.tag }}.md"
 
       - name: Publish GitHub Release
         uses: softprops/action-gh-release@v3
         with:
-          tag_name: ${{ steps.meta.outputs.tag }}
-          body_path: docs/releases/release-${{ steps.meta.outputs.tag }}.md
+          tag_name: ${{ needs.release-context.outputs.tag }}
+          body_path: docs/releases/release-${{ needs.release-context.outputs.tag }}.md

--- a/docs/design/v0.21-nightly-e2e-stability.md
+++ b/docs/design/v0.21-nightly-e2e-stability.md
@@ -29,6 +29,7 @@
 - [x] 2026-08-16 scheduled main nightly（run `31922896563`）在 `c3f8545` 双 suite 成功；这是最终修复后第 2 次连续成功。
 - [x] 合并路由熔断修复与迁移守卫到 main（merge `d5b0024`）后，手动 nightly（run `31924463747`）双 suite 成功；这是最终修复后第 3 次连续成功。
 - [x] 2026-08-17 手动 main nightly（run `31988458006`）在 `336b130`（v0.20.4 发布基线）双 suite 成功；这是最终修复后第 4 次连续成功。
+- [x] 2026-08-17 scheduled main nightly（run `31989324792`）仍在 `336b130` 双 suite 成功；这是最终修复后第 5 次连续成功，达到 5 / 5 准入标准。
 
 ## 3. Run 记录
 
@@ -67,4 +68,4 @@
 | 2 | 2026-08-16 02:52 UTC | main | `c3f8545` | success | success | 2 / 5（scheduled run `31922896563`） |
 | 3 | 2026-08-16 03:31 UTC | main | `d5b0024` | success | success | 3 / 5（run `31924463747`） |
 | 4 | 2026-08-17 02:35 UTC | main | `336b130` | success | success | 4 / 5（run `31988458006`） |
-| — | 下一次 main nightly | — | — | — | — | 待记录（再成功 1 次即达准入标准） |
+| 5 | 2026-08-17 02:52 UTC | main | `336b130` | success | success | 5 / 5（scheduled run `31989324792`，达到准入标准） |

--- a/docs/design/v0.21-nightly-e2e-stability.md
+++ b/docs/design/v0.21-nightly-e2e-stability.md
@@ -30,6 +30,7 @@
 - [x] 合并路由熔断修复与迁移守卫到 main（merge `d5b0024`）后，手动 nightly（run `31924463747`）双 suite 成功；这是最终修复后第 3 次连续成功。
 - [x] 2026-08-17 手动 main nightly（run `31988458006`）在 `336b130`（v0.20.4 发布基线）双 suite 成功；这是最终修复后第 4 次连续成功。
 - [x] 2026-08-17 scheduled main nightly（run `31989324792`）仍在 `336b130` 双 suite 成功；这是最终修复后第 5 次连续成功，达到 5 / 5 准入标准。
+- [x] 2026-08-18 在 `ci/release-e2e-gate@be8e46e` 手动触发 reusable Nightly E2E（run `32087512854`）双 suite 成功；该记录验证 workflow 抽取本身，不计入 main 稳定性准入计数。
 
 ## 3. Run 记录
 

--- a/docs/design/v0.21-roadmap.md
+++ b/docs/design/v0.21-roadmap.md
@@ -14,7 +14,7 @@
 | P0 | v0.20 迁移后首个结算周期对账 | ✅ 已完成（2026-08-14） | 首个完整结算周期于 v0.20.0 上线当日（2026-08-14）执行对账，验收全部通过；记录见 [v0.21-p0-reconciliation-record.md](./v0.21-p0-reconciliation-record.md) |
 | P0 | 文档事实源收口 | ✅ 本路线图建立 | v0.19 执行记录已归档，TODO/README 入口已同步 |
 | P1 | MySQL/Postgres migration smoke | ✅ 已完成（2026-08-14） | CI `Migration smoke (mysql)` / `(postgres)` 均通过；覆盖 fresh、repeat、状态审计与失败注入 |
-| P1 | release 挂钩 admin e2e | 🔄 稳定性计数中 | 最终 export 竞态修复后 main nightly 已连续 4 次双 suite 成功（含 2026-08-16 scheduled run `31922896563`、`d5b0024` 手动 run `31924463747` 与 2026-08-17 手动 run `31988458006`）；准入标准为连续 5 次或稳定 1–2 周。记录见 [v0.21-nightly-e2e-stability.md](./v0.21-nightly-e2e-stability.md) |
+| P1 | release 挂钩 admin e2e | 🔄 已接入，待真实发布验证 | nightly 已连续 5 次双 suite 成功（最后为 2026-08-17 scheduled run `31989324792`）；`e2e.yml` 抽为 nightly / release 共用工作流，release 在 Docker 发布前执行 E2E，失败即阻断。还需一次真实 tag 发布完成闭环。记录见 [v0.21-nightly-e2e-stability.md](./v0.21-nightly-e2e-stability.md) |
 | P2 | P3-0 指标季度观察基线 | 🔄 首次快照已建立 | 可复用模板见 [p3-quarterly-baseline-template.md](../observability/p3-quarterly-baseline-template.md)；首次快照见 [p3-baseline-2026Q3.md](../observability/p3-baseline-2026Q3.md)。Prometheus 保留窗口约 41h、Grafana 只读凭据缺失，dedupe 冲突 counter 缺口均已登记 |
 | P2 | 手动分区 DDL 预演 | ⬜ 触发式 | 达到 1GB / 1000 万行阈值前演练；必须先应用迁移 `078`；手动脚本前置守卫已补齐（见 §4.2） |
 | P2 | P2.3 热点文件拆分 | ⬜ 触发式 | 仅在对应文件因业务需求再次修改时启动 |
@@ -64,9 +64,10 @@ v0.21 阶段执行期间已继续发布两个兼容性 PATCH：[v0.20.1](../rele
 
 ### 3.2 release 挂钩 admin e2e（先准入，后提升）
 
-- 前置条件：nightly compose E2E + Playwright admin smoke 在 v0.20.0 修复后连续稳定（建议连续 5 次或稳定 1–2 周）；
-- 当前阻塞：2026-08-14 main nightly（run `31768353982`）compose E2E 与 Playwright 双失败；同日 develop 手动触发（run `31766504932`）双成功。需下载失败工件，先区分代码回归、环境/外部依赖波动与 flaky，再建立逐日稳定性记录；
-- 验收：nightly 达到稳定标准后，release tag 工作流在镜像发布前执行 e2e，失败即阻断发布；失败工件上传保留，并至少经历一次真实发布验证。
+- 前置条件：nightly compose E2E + Playwright admin smoke 在 v0.20.0 修复后连续稳定（建议连续 5 次或稳定 1–2 周）；✅（2026-08-17 最终修复后连续 5 次成功，最后为 scheduled run `31989324792`）
+- 当前状态：✅ `nightly.yml` 改为调用 reusable `e2e.yml`（compose E2E + Playwright admin smoke 单一事实源）；`release.yml` 通过 `release-context` 解析目标 tag，并把 E2E 设为 Docker 构建 / 推送与 GitHub Release 的前置依赖。E2E 失败时镜像和 Release 均不会发布。
+- 剩余闭环：合并后需经历一次真实 release，确认 tag 基线上 E2E 先行、镜像与 GitHub Release 均成功，并保留失败工件上传能力证据。
+- 验收：release tag 工作流在镜像发布前执行 e2e，失败即阻断发布；失败工件上传保留，并至少经历一次真实发布验证。
 
 ## 4. P2 — 观察基线与触发式沉淀
 

--- a/docs/design/v0.21-roadmap.md
+++ b/docs/design/v0.21-roadmap.md
@@ -66,6 +66,7 @@ v0.21 阶段执行期间已继续发布两个兼容性 PATCH：[v0.20.1](../rele
 
 - 前置条件：nightly compose E2E + Playwright admin smoke 在 v0.20.0 修复后连续稳定（建议连续 5 次或稳定 1–2 周）；✅（2026-08-17 最终修复后连续 5 次成功，最后为 scheduled run `31989324792`）
 - 当前状态：✅ `nightly.yml` 改为调用 reusable `e2e.yml`（compose E2E + Playwright admin smoke 单一事实源）；`release.yml` 通过 `release-context` 解析目标 tag，并把 E2E 设为 Docker 构建 / 推送与 GitHub Release 的前置依赖。E2E 失败时镜像和 Release 均不会发布。
+- 远端调用验证：✅ 2026-08-18 在 `ci/release-e2e-gate@be8e46e` 手动触发 Nightly E2E（run `32087512854`），`e2e / Compose E2E suite` 与 `e2e / Playwright admin smoke` 双 suite 成功，证明 reusable workflow 在远端可调用且语义正常。
 - 剩余闭环：合并后需经历一次真实 release，确认 tag 基线上 E2E 先行、镜像与 GitHub Release 均成功，并保留失败工件上传能力证据。
 - 验收：release tag 工作流在镜像发布前执行 e2e，失败即阻断发布；失败工件上传保留，并至少经历一次真实发布验证。
 


### PR DESCRIPTION
## Summary
- record the fifth consecutive successful main nightly run and confirm the 5/5 release-E2E admission threshold
- extract compose E2E and Playwright admin smoke into a reusable `e2e.yml` workflow
- make nightly invoke the shared workflow and place the E2E gate before release Docker publish and GitHub Release
- verify the reusable workflow remotely on this branch and record run `32087512854`

## Validation
- YAML parse check for `e2e.yml`, `nightly.yml`, and `release.yml`
- `python3 scripts/check-markdown-links.py`
- `git diff --check`
- Remote reusable E2E run `32087512854`: Compose E2E and Playwright admin smoke both succeeded

## Follow-up
- After merge, validate the complete release path with a real tag: E2E must pass before image publishing and GitHub Release publication.